### PR TITLE
Update remote development instructions to OpenShift Origin 3.6

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -217,10 +217,10 @@
           <section class='col-xs-12 col-sm-6 col-md-6'>
             <section>
               <h2>Deploying code changes</h2>
-                <p>OpenShift uses the <a href="http://git-scm.com/">Git version control system</a> for your source code, and grants you access to it via the Secure Shell (SSH) protocol. In order to upload and download code to your application you need to give us your <a href="https://www.openshift.com/developers/remote-access">public SSH key</a>. You can upload it within the web console or install the <a href="https://www.openshift.com/developers/rhc-client-tools-install">RHC command line tool</a> and run <code>rhc setup</code> to generate and upload your key automatically.</p>
+                <p>OpenShift uses the <a href="http://git-scm.com/">Git version control system</a> for your source code, and grants you access to it via the Secure Shell (SSH) protocol through the [OpenShift Client Remote Shell](https://docs.openshift.org/latest/dev_guide/ssh_environment.html) `oc rsh`.</p>
                 
                 <h3>Working in your local Git repository</h3>
-                <p>If you created your application from the command line and uploaded your SSH key, rhc will automatically download a copy of that source code repository (Git calls this 'cloning') to your local system.</p>
+                <p>If you created your application from the command line and uploaded your SSH key, `oc` will automatically download a copy of that source code repository (Git calls this 'cloning') to your local system.</p>
 
                 <p>If you created the application from the web console, you'll need to manually clone the repository to your local system. Copy the application's source code Git URL and then run:</p>
 


### PR DESCRIPTION
This was written on a best effort basis after tinkering with `oc rsh` and `oc rsync` for a few minutes. Someone might want to rework the whole page, since it seems a lot has changed since it was originally written.