### PR TITLE
Upgrade warPlugin for jdk17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
           <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.3.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <outputDirectory>target</outputDirectory>


### PR DESCRIPTION
The war plugin 2.3 is not compatible with JDK17. This test app can't be built. It is used by wildfly openshift testsuite.